### PR TITLE
Fix missing summon_raptor minion data

### DIFF
--- a/src/Data/minions.json
+++ b/src/Data/minions.json
@@ -105,6 +105,15 @@
     "name": "StormTotem",
     "life": "120"
   },
+  "Summon_Raptor": {
+    "skillList": [
+      "FeatheredRaptorJumpSlash",
+      "BasicEnemyMelee"
+    ],
+    "modList": [],
+    "name": "PrimalRaptor",
+    "life": "240"
+  },
   "SummonedAbomination": {
     "skillList": [
       "Abomination Melee"

--- a/src/Data/skills.json
+++ b/src/Data/skills.json
@@ -2300,6 +2300,25 @@
       "base_skill_effect_duration": 10
     }
   },
+  "FeatheredRaptorJumpSlash": {
+    "name": "Melee Attack",
+    "skillTypeTags": 513,
+    "castTime": 1.2727273,
+    "baseFlags": {
+      "melee": true,
+      "attack": true,
+      "hit": true,
+      "duration": true
+    },
+    "stats": {
+      "damageEffectiveness": 1,
+      "melee_base_physical_damage": 18,
+      "base_critical_strike_multiplier_+": 100,
+      "critChance": 5,
+      "base_skill_effect_duration": 10,
+      "cooldown": 4
+    }
+  },
   "FrenzyAura": {
     "name": "Frenzy Aura",
     "skillTypeTags": 131328,


### PR DESCRIPTION
Fixes #34 

### Description of the problem being solved:
The data for the raptor minion was missing from the extracted data