### PR TITLE
Fix passive point allocations no longer displayed with new runtime

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -626,7 +626,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		if base then
 			self:DrawAsset(base, scrX, scrY, scale)
 			-- Draw the allocated number
-			DrawString(scrX - 48 * scale, scrY + 32 * scale, "LEFT", 90 * scale, "VAR", node.alloc .. "/" .. node.maxPoints)
+			DrawString(scrX - 48 * scale, scrY + 32 * scale, "LEFT", round(90 * scale), "VAR", "^7" .. node.alloc .. "/" .. node.maxPoints)
 		end
 
 		if overlay then


### PR DESCRIPTION
### Description of the problem being solved:

The new runtime seems to not handle drawing string with a decimal font size
<img width="786" height="354" alt="Screenshot 2025-08-03 213255" src="https://github.com/user-attachments/assets/8920ecb8-d350-4e78-90ef-5b04086cf251" />
Should be:
<img width="802" height="353" alt="Screenshot 2025-08-03 213307" src="https://github.com/user-attachments/assets/fc20bd31-bc33-4bfa-b860-c8c5d38db926" />
