### PR TITLE
Improve automate release

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -4,11 +4,14 @@ on:
     workflows: ["Run Tests"]
     branches: [dev]
     types: [completed]
+  push:
+    tags:
+      - v** 
   workflow_dispatch:
 jobs:
   push-beta:
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'push' }}
     steps:
       - name: Set line endings
         run: git config --global core.autocrlf true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
               uses: peter-evans/create-pull-request@v7
               with:
                   token: ${{ steps.app-token.outputs.token }}
-                  draft: true
                   title: Release ${{ env.NEXT_VERSION }}
                   branch: release-${{ env.NEXT_VERSION }}
                   body: |

--- a/.github/workflows/sync-release-to-master.yml
+++ b/.github/workflows/sync-release-to-master.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Publish release
         run: |
           VERSION=$(echo ${{ github.head_ref }} | sed 's/release-//')
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh release edit v$VERSION --draft=false


### PR DESCRIPTION
### Description of the problem being solved:
* Fix the gh login when publishing automatically the release
* Create directly the release PR without draft mode
* Fix beta workflow on tag push

- [ ] Automatically force PR to be up-to-date when the release PR is made, then rollback when the release PR is merged
